### PR TITLE
Update templates for zabbix 6.4 (closes #7)

### DIFF
--- a/zbx_template_PaloAltoNGFW.json
+++ b/zbx_template_PaloAltoNGFW.json
@@ -28,7 +28,6 @@
                         "history": "30d",
                         "units": "%",
                         "description": "The average, over the last minute, of the percentage of time that this processor was not idle. Implementations may approximate this one minute smoothing period if necessary.",
-                        "request_method": "POST",
                         "triggers": [
                             {
                                 "uuid": "95a6bd8630fa456a9561750cbe1654e4",
@@ -47,7 +46,6 @@
                         "history": "30d",
                         "units": "%",
                         "description": "The average, over the last minute, of the percentage of time that this processor was not idle. Implementations may approximate this one minute smoothing period if necessary.",
-                        "request_method": "POST",
                         "triggers": [
                             {
                                 "uuid": "0894b9b8b4854aa2ab27cd47ff9c553e",
@@ -75,7 +73,6 @@
                                 ]
                             }
                         ],
-                        "request_method": "POST",
                         "triggers": [
                             {
                                 "uuid": "709b3fb1eef14529ab27b1f31107bc43",
@@ -96,8 +93,7 @@
                         "trends": "0",
                         "value_type": "TEXT",
                         "description": "Chassis type for this Palo Alto device.",
-                        "inventory_link": "MODEL",
-                        "request_method": "POST"
+                        "inventory_link": "MODEL"
                     },
                     {
                         "uuid": "e2d110b53e054707838ad9217f2744e8",
@@ -145,8 +141,7 @@
                         "snmp_oid": ".1.3.6.1.4.1.25461.2.1.2.3.3.0",
                         "key": "panSessionActive",
                         "history": "30d",
-                        "description": "Total number of active sessions.",
-                        "request_method": "POST"
+                        "description": "Total number of active sessions."
                     },
                     {
                         "uuid": "63f7cd5c863c4a9b9f6d2aaa30e43964",
@@ -184,8 +179,7 @@
                         "delay": "1d",
                         "history": "7d",
                         "trends": "0",
-                        "description": "Total number of sessions supported.",
-                        "request_method": "POST"
+                        "description": "Total number of sessions supported."
                     },
                     {
                         "uuid": "28a534703c6049d0abfa8622cabfac72",
@@ -230,7 +224,6 @@
                         "trends": "0",
                         "value_type": "TEXT",
                         "description": "Currently installed application definition version. If no application definition is found, 0 is returned.",
-                        "request_method": "POST",
                         "triggers": [
                             {
                                 "uuid": "394584e124f6433bb41cbbd867348144",
@@ -252,7 +245,6 @@
                         "trends": "0",
                         "value_type": "TEXT",
                         "description": "Currently installed global-protect client package version. If package is not installed, 0.0.0 is returned.",
-                        "request_method": "POST",
                         "triggers": [
                             {
                                 "uuid": "211061de1d274109820af7f1e27ab337",
@@ -273,8 +265,7 @@
                         "history": "30d",
                         "trends": "0",
                         "value_type": "TEXT",
-                        "description": "Current high-availability mode (disabled, active-passive, or active-active).",
-                        "request_method": "POST"
+                        "description": "Current high-availability mode (disabled, active-passive, or active-active)."
                     },
                     {
                         "uuid": "fbeb733e9a224df8a65edd6a35e5a13d",
@@ -285,8 +276,7 @@
                         "history": "30d",
                         "trends": "0",
                         "value_type": "TEXT",
-                        "description": "Current peer high-availability state.",
-                        "request_method": "POST"
+                        "description": "Current peer high-availability state."
                     },
                     {
                         "uuid": "69c101bad9d74bfc83d33e590e2e2dd2",
@@ -298,7 +288,6 @@
                         "trends": "0",
                         "value_type": "TEXT",
                         "description": "Current high-availability state.",
-                        "request_method": "POST",
                         "triggers": [
                             {
                                 "uuid": "937c5fe5976a42c6bfc06ce7add11211",
@@ -320,8 +309,7 @@
                         "trends": "0",
                         "value_type": "TEXT",
                         "description": "Hardware version of the unit.",
-                        "inventory_link": "HARDWARE",
-                        "request_method": "POST"
+                        "inventory_link": "HARDWARE"
                     },
                     {
                         "uuid": "6ddb1ff37b0e4ff890ee4d4ee900ee0f",
@@ -335,7 +323,6 @@
                         "value_type": "TEXT",
                         "description": "The serial number of the unit. If not available, an empty string is returned.",
                         "inventory_link": "SERIALNO_A",
-                        "request_method": "POST",
                         "triggers": [
                             {
                                 "uuid": "37187e18b830450ab673440df4e982c3",
@@ -359,7 +346,6 @@
                         "value_type": "TEXT",
                         "description": "Full software version. The first two components of the full version are the major and minor versions. The third component indicates the maintenance release number.",
                         "inventory_link": "OS",
-                        "request_method": "POST",
                         "triggers": [
                             {
                                 "uuid": "1758114fdda2498b9c252ae8bc8b6cbb",
@@ -382,7 +368,6 @@
                         "trends": "0",
                         "value_type": "TEXT",
                         "description": "Currently installed threat definition version. If no threat definition is found, 0 is returned.",
-                        "request_method": "POST",
                         "triggers": [
                             {
                                 "uuid": "efee5e6656414ba3b35ca6d1c686e03c",
@@ -404,7 +389,6 @@
                         "trends": "0",
                         "value_type": "TEXT",
                         "description": "Currently installed URL filtering version. If no URL filtering is installed, 0 is returned.",
-                        "request_method": "POST",
                         "triggers": [
                             {
                                 "uuid": "1bab31c0072f4c51999a71675fd370c9",
@@ -427,8 +411,7 @@
                         "trends": "0",
                         "value_type": "TEXT",
                         "description": "A textual description of the entity.  This value should include the full name and version identification of the system's hardware type, software operating-system, and networking software.  It is mandatory that this only contain printable ASCII characters.",
-                        "inventory_link": "TYPE",
-                        "request_method": "POST"
+                        "inventory_link": "TYPE"
                     },
                     {
                         "uuid": "a1bb135924e84e7f8b679db16790e34f",
@@ -442,7 +425,6 @@
                         "value_type": "TEXT",
                         "description": "An administratively-assigned name for this managed node.  By convention, this is the node's fully-qualified domain name.",
                         "inventory_link": "NAME",
-                        "request_method": "POST",
                         "triggers": [
                             {
                                 "uuid": "e9f0b816900c4866a4dd36b57048a09b",
@@ -471,7 +453,6 @@
                                 ]
                             }
                         ],
-                        "request_method": "POST",
                         "triggers": [
                             {
                                 "uuid": "0411fb1410784a209dc9d217446ecd40",
@@ -492,8 +473,7 @@
                         "trends": "0d",
                         "valuemap": {
                             "name": "zabbix.host.available"
-                        },
-                        "request_method": "POST"
+                        }
                     }
                 ],
                 "discovery_rules": [
@@ -522,7 +502,6 @@
                                 "snmp_oid": ".1.3.6.1.2.1.99.1.1.1.5.{#SNMPINDEX}",
                                 "key": "entPhySensorOperStatus[{#SNMPVALUE},FAN]",
                                 "delay": "300",
-                                "request_method": "POST",
                                 "trigger_prototypes": [
                                     {
                                         "uuid": "d16b7a342c824cbab29e21da46cc2ca1",
@@ -541,11 +520,9 @@
                                 "key": "entPhySensorValue[{#SNMPINDEX},FAN]",
                                 "delay": "60",
                                 "units": "rpm",
-                                "description": "ENTITY-SENSOR-MIB::entPhySensorValue&#13;\n&#13;\nThe most recent measurement obtained by the agent for this sensor.",
-                                "request_method": "POST"
+                                "description": "ENTITY-SENSOR-MIB::entPhySensorValue&#13;\n&#13;\nThe most recent measurement obtained by the agent for this sensor."
                             }
-                        ],
-                        "request_method": "POST"
+                        ]
                     },
                     {
                         "uuid": "b133aa1d7a854de38ad786767b5a4148",
@@ -572,8 +549,7 @@
                                 "snmp_oid": ".1.3.6.1.2.1.99.1.1.1.5.{#SNMPINDEX}",
                                 "key": "entPhySensorOperStatus[{#SNMPINDEX},TEMPERATURE]",
                                 "delay": "300",
-                                "description": "Discovery of alarm status at temperature sensor",
-                                "request_method": "POST"
+                                "description": "Discovery of alarm status at temperature sensor"
                             },
                             {
                                 "uuid": "f3d1cc596b2d441496d501393eb358e9",
@@ -583,8 +559,7 @@
                                 "key": "entPhySensorValue[{#SNMPINDEX},TEMPERATURE]",
                                 "delay": "60",
                                 "units": "\u00b0C",
-                                "description": "Temperature item discovery",
-                                "request_method": "POST"
+                                "description": "Temperature item discovery"
                             }
                         ],
                         "trigger_prototypes": [
@@ -609,8 +584,7 @@
                                     }
                                 ]
                             }
-                        ],
-                        "request_method": "POST"
+                        ]
                     }
                 ],
                 "valuemaps": [

--- a/zbx_template_PaloAltoNGFW.xml
+++ b/zbx_template_PaloAltoNGFW.xml
@@ -28,7 +28,6 @@
                     <history>30d</history>
                     <units>%</units>
                     <description>The average, over the last minute, of the percentage of time that this processor was not idle. Implementations may approximate this one minute smoothing period if necessary.</description>
-                    <request_method>POST</request_method>
                     <triggers>
                         <trigger>
                             <uuid>95a6bd8630fa456a9561750cbe1654e4</uuid>
@@ -47,7 +46,6 @@
                     <history>30d</history>
                     <units>%</units>
                     <description>The average, over the last minute, of the percentage of time that this processor was not idle. Implementations may approximate this one minute smoothing period if necessary.</description>
-                    <request_method>POST</request_method>
                     <triggers>
                         <trigger>
                             <uuid>0894b9b8b4854aa2ab27cd47ff9c553e</uuid>
@@ -75,7 +73,6 @@
                             </parameters>
                         </step>
                     </preprocessing>
-                    <request_method>POST</request_method>
                     <triggers>
                         <trigger>
                             <uuid>709b3fb1eef14529ab27b1f31107bc43</uuid>
@@ -97,7 +94,6 @@
                     <value_type>TEXT</value_type>
                     <description>Chassis type for this Palo Alto device.</description>
                     <inventory_link>MODEL</inventory_link>
-                    <request_method>POST</request_method>
                 </item>
                 <item>
                     <uuid>e2d110b53e054707838ad9217f2744e8</uuid>
@@ -146,7 +142,6 @@
                     <key>panSessionActive</key>
                     <history>30d</history>
                     <description>Total number of active sessions.</description>
-                    <request_method>POST</request_method>
                 </item>
                 <item>
                     <uuid>63f7cd5c863c4a9b9f6d2aaa30e43964</uuid>
@@ -185,7 +180,6 @@
                     <history>7d</history>
                     <trends>0</trends>
                     <description>Total number of sessions supported.</description>
-                    <request_method>POST</request_method>
                 </item>
                 <item>
                     <uuid>28a534703c6049d0abfa8622cabfac72</uuid>
@@ -230,7 +224,6 @@
                     <trends>0</trends>
                     <value_type>TEXT</value_type>
                     <description>Currently installed application definition version. If no application definition is found, 0 is returned.</description>
-                    <request_method>POST</request_method>
                     <triggers>
                         <trigger>
                             <uuid>394584e124f6433bb41cbbd867348144</uuid>
@@ -252,7 +245,6 @@
                     <trends>0</trends>
                     <value_type>TEXT</value_type>
                     <description>Currently installed global-protect client package version. If package is not installed, 0.0.0 is returned.</description>
-                    <request_method>POST</request_method>
                     <triggers>
                         <trigger>
                             <uuid>211061de1d274109820af7f1e27ab337</uuid>
@@ -274,7 +266,6 @@
                     <trends>0</trends>
                     <value_type>TEXT</value_type>
                     <description>Current high-availability mode (disabled, active-passive, or active-active).</description>
-                    <request_method>POST</request_method>
                 </item>
                 <item>
                     <uuid>fbeb733e9a224df8a65edd6a35e5a13d</uuid>
@@ -286,7 +277,6 @@
                     <trends>0</trends>
                     <value_type>TEXT</value_type>
                     <description>Current peer high-availability state.</description>
-                    <request_method>POST</request_method>
                 </item>
                 <item>
                     <uuid>69c101bad9d74bfc83d33e590e2e2dd2</uuid>
@@ -298,7 +288,6 @@
                     <trends>0</trends>
                     <value_type>TEXT</value_type>
                     <description>Current high-availability state.</description>
-                    <request_method>POST</request_method>
                     <triggers>
                         <trigger>
                             <uuid>937c5fe5976a42c6bfc06ce7add11211</uuid>
@@ -321,7 +310,6 @@
                     <value_type>TEXT</value_type>
                     <description>Hardware version of the unit.</description>
                     <inventory_link>HARDWARE</inventory_link>
-                    <request_method>POST</request_method>
                 </item>
                 <item>
                     <uuid>6ddb1ff37b0e4ff890ee4d4ee900ee0f</uuid>
@@ -335,7 +323,6 @@
                     <value_type>TEXT</value_type>
                     <description>The serial number of the unit. If not available, an empty string is returned.</description>
                     <inventory_link>SERIALNO_A</inventory_link>
-                    <request_method>POST</request_method>
                     <triggers>
                         <trigger>
                             <uuid>37187e18b830450ab673440df4e982c3</uuid>
@@ -360,7 +347,6 @@ Device serial number has changed. Ack to close</description>
                     <value_type>TEXT</value_type>
                     <description>Full software version. The first two components of the full version are the major and minor versions. The third component indicates the maintenance release number.</description>
                     <inventory_link>OS</inventory_link>
-                    <request_method>POST</request_method>
                     <triggers>
                         <trigger>
                             <uuid>1758114fdda2498b9c252ae8bc8b6cbb</uuid>
@@ -383,7 +369,6 @@ Device serial number has changed. Ack to close</description>
                     <trends>0</trends>
                     <value_type>TEXT</value_type>
                     <description>Currently installed threat definition version. If no threat definition is found, 0 is returned.</description>
-                    <request_method>POST</request_method>
                     <triggers>
                         <trigger>
                             <uuid>efee5e6656414ba3b35ca6d1c686e03c</uuid>
@@ -405,7 +390,6 @@ Device serial number has changed. Ack to close</description>
                     <trends>0</trends>
                     <value_type>TEXT</value_type>
                     <description>Currently installed URL filtering version. If no URL filtering is installed, 0 is returned.</description>
-                    <request_method>POST</request_method>
                     <triggers>
                         <trigger>
                             <uuid>1bab31c0072f4c51999a71675fd370c9</uuid>
@@ -429,7 +413,6 @@ Device serial number has changed. Ack to close</description>
                     <value_type>TEXT</value_type>
                     <description>A textual description of the entity.  This value should include the full name and version identification of the system's hardware type, software operating-system, and networking software.  It is mandatory that this only contain printable ASCII characters.</description>
                     <inventory_link>TYPE</inventory_link>
-                    <request_method>POST</request_method>
                 </item>
                 <item>
                     <uuid>a1bb135924e84e7f8b679db16790e34f</uuid>
@@ -443,7 +426,6 @@ Device serial number has changed. Ack to close</description>
                     <value_type>TEXT</value_type>
                     <description>An administratively-assigned name for this managed node.  By convention, this is the node's fully-qualified domain name.</description>
                     <inventory_link>NAME</inventory_link>
-                    <request_method>POST</request_method>
                     <triggers>
                         <trigger>
                             <uuid>e9f0b816900c4866a4dd36b57048a09b</uuid>
@@ -472,7 +454,6 @@ Device serial number has changed. Ack to close</description>
                             </parameters>
                         </step>
                     </preprocessing>
-                    <request_method>POST</request_method>
                     <triggers>
                         <trigger>
                             <uuid>0411fb1410784a209dc9d217446ecd40</uuid>
@@ -494,7 +475,6 @@ Device serial number has changed. Ack to close</description>
                     <valuemap>
                         <name>zabbix.host.available</name>
                     </valuemap>
-                    <request_method>POST</request_method>
                 </item>
             </items>
             <discovery_rules>
@@ -523,7 +503,6 @@ Device serial number has changed. Ack to close</description>
                             <snmp_oid>.1.3.6.1.2.1.99.1.1.1.5.{#SNMPINDEX}</snmp_oid>
                             <key>entPhySensorOperStatus[{#SNMPVALUE},FAN]</key>
                             <delay>300</delay>
-                            <request_method>POST</request_method>
                             <trigger_prototypes>
                                 <trigger_prototype>
                                     <uuid>d16b7a342c824cbab29e21da46cc2ca1</uuid>
@@ -545,10 +524,8 @@ Device serial number has changed. Ack to close</description>
                             <description>ENTITY-SENSOR-MIB::entPhySensorValue&amp;#13;
 &amp;#13;
 The most recent measurement obtained by the agent for this sensor.</description>
-                            <request_method>POST</request_method>
                         </item_prototype>
                     </item_prototypes>
-                    <request_method>POST</request_method>
                 </discovery_rule>
                 <discovery_rule>
                     <uuid>b133aa1d7a854de38ad786767b5a4148</uuid>
@@ -576,7 +553,6 @@ The most recent measurement obtained by the agent for this sensor.</description>
                             <key>entPhySensorOperStatus[{#SNMPINDEX},TEMPERATURE]</key>
                             <delay>300</delay>
                             <description>Discovery of alarm status at temperature sensor</description>
-                            <request_method>POST</request_method>
                         </item_prototype>
                         <item_prototype>
                             <uuid>f3d1cc596b2d441496d501393eb358e9</uuid>
@@ -587,7 +563,6 @@ The most recent measurement obtained by the agent for this sensor.</description>
                             <delay>60</delay>
                             <units>°C</units>
                             <description>Temperature item discovery</description>
-                            <request_method>POST</request_method>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
@@ -613,7 +588,6 @@ The most recent measurement obtained by the agent for this sensor.</description>
                             </graph_items>
                         </graph_prototype>
                     </graph_prototypes>
-                    <request_method>POST</request_method>
                 </discovery_rule>
             </discovery_rules>
             <valuemaps>

--- a/zbx_template_PaloAltoNGFW.yaml
+++ b/zbx_template_PaloAltoNGFW.yaml
@@ -23,7 +23,6 @@ zabbix_export:
           history: 30d
           units: '%'
           description: 'The average, over the last minute, of the percentage of time that this processor was not idle. Implementations may approximate this one minute smoothing period if necessary.'
-          request_method: POST
           triggers:
             -
               uuid: 95a6bd8630fa456a9561750cbe1654e4
@@ -39,7 +38,6 @@ zabbix_export:
           history: 30d
           units: '%'
           description: 'The average, over the last minute, of the percentage of time that this processor was not idle. Implementations may approximate this one minute smoothing period if necessary.'
-          request_method: POST
           triggers:
             -
               uuid: 0894b9b8b4854aa2ab27cd47ff9c553e
@@ -60,7 +58,6 @@ zabbix_export:
               type: BOOL_TO_DECIMAL
               parameters:
                 - ''
-          request_method: POST
           triggers:
             -
               uuid: 709b3fb1eef14529ab27b1f31107bc43
@@ -79,7 +76,6 @@ zabbix_export:
           value_type: TEXT
           description: 'Chassis type for this Palo Alto device.'
           inventory_link: MODEL
-          request_method: POST
         -
           uuid: e2d110b53e054707838ad9217f2744e8
           name: 'GP active tunnels'
@@ -122,7 +118,6 @@ zabbix_export:
           key: panSessionActive
           history: 30d
           description: 'Total number of active sessions.'
-          request_method: POST
         -
           uuid: 63f7cd5c863c4a9b9f6d2aaa30e43964
           name: 'Total active ICMP sessions'
@@ -157,7 +152,6 @@ zabbix_export:
           history: 7d
           trends: '0'
           description: 'Total number of sessions supported.'
-          request_method: POST
         -
           uuid: 28a534703c6049d0abfa8622cabfac72
           name: 'Session table utilization'
@@ -197,7 +191,6 @@ zabbix_export:
           trends: '0'
           value_type: TEXT
           description: 'Currently installed application definition version. If no application definition is found, 0 is returned.'
-          request_method: POST
           triggers:
             -
               uuid: 394584e124f6433bb41cbbd867348144
@@ -216,7 +209,6 @@ zabbix_export:
           trends: '0'
           value_type: TEXT
           description: 'Currently installed global-protect client package version. If package is not installed, 0.0.0 is returned.'
-          request_method: POST
           triggers:
             -
               uuid: 211061de1d274109820af7f1e27ab337
@@ -235,7 +227,6 @@ zabbix_export:
           trends: '0'
           value_type: TEXT
           description: 'Current high-availability mode (disabled, active-passive, or active-active).'
-          request_method: POST
         -
           uuid: fbeb733e9a224df8a65edd6a35e5a13d
           name: 'HA Peer State'
@@ -246,7 +237,6 @@ zabbix_export:
           trends: '0'
           value_type: TEXT
           description: 'Current peer high-availability state.'
-          request_method: POST
         -
           uuid: 69c101bad9d74bfc83d33e590e2e2dd2
           name: 'HA State'
@@ -257,7 +247,6 @@ zabbix_export:
           trends: '0'
           value_type: TEXT
           description: 'Current high-availability state.'
-          request_method: POST
           triggers:
             -
               uuid: 937c5fe5976a42c6bfc06ce7add11211
@@ -277,7 +266,6 @@ zabbix_export:
           value_type: TEXT
           description: 'Hardware version of the unit.'
           inventory_link: HARDWARE
-          request_method: POST
         -
           uuid: 6ddb1ff37b0e4ff890ee4d4ee900ee0f
           name: 'Serial Number'
@@ -290,7 +278,6 @@ zabbix_export:
           value_type: TEXT
           description: 'The serial number of the unit. If not available, an empty string is returned.'
           inventory_link: SERIALNO_A
-          request_method: POST
           triggers:
             -
               uuid: 37187e18b830450ab673440df4e982c3
@@ -313,7 +300,6 @@ zabbix_export:
           value_type: TEXT
           description: 'Full software version. The first two components of the full version are the major and minor versions. The third component indicates the maintenance release number.'
           inventory_link: OS
-          request_method: POST
           triggers:
             -
               uuid: 1758114fdda2498b9c252ae8bc8b6cbb
@@ -333,7 +319,6 @@ zabbix_export:
           trends: '0'
           value_type: TEXT
           description: 'Currently installed threat definition version. If no threat definition is found, 0 is returned.'
-          request_method: POST
           triggers:
             -
               uuid: efee5e6656414ba3b35ca6d1c686e03c
@@ -352,7 +337,6 @@ zabbix_export:
           trends: '0'
           value_type: TEXT
           description: 'Currently installed URL filtering version. If no URL filtering is installed, 0 is returned.'
-          request_method: POST
           triggers:
             -
               uuid: 1bab31c0072f4c51999a71675fd370c9
@@ -373,7 +357,6 @@ zabbix_export:
           value_type: TEXT
           description: 'A textual description of the entity.  This value should include the full name and version identification of the system''s hardware type, software operating-system, and networking software.  It is mandatory that this only contain printable ASCII characters.'
           inventory_link: TYPE
-          request_method: POST
         -
           uuid: a1bb135924e84e7f8b679db16790e34f
           name: 'System Name'
@@ -386,7 +369,6 @@ zabbix_export:
           value_type: TEXT
           description: 'An administratively-assigned name for this managed node.  By convention, this is the node''s fully-qualified domain name.'
           inventory_link: NAME
-          request_method: POST
           triggers:
             -
               uuid: e9f0b816900c4866a4dd36b57048a09b
@@ -409,7 +391,6 @@ zabbix_export:
               type: MULTIPLIER
               parameters:
                 - '.01'
-          request_method: POST
           triggers:
             -
               uuid: 0411fb1410784a209dc9d217446ecd40
@@ -427,7 +408,6 @@ zabbix_export:
           trends: 0d
           valuemap:
             name: zabbix.host.available
-          request_method: POST
       discovery_rules:
         -
           uuid: 8916021e8f9f415685f1e8b8e376ff2f
@@ -451,7 +431,6 @@ zabbix_export:
               snmp_oid: '.1.3.6.1.2.1.99.1.1.1.5.{#SNMPINDEX}'
               key: 'entPhySensorOperStatus[{#SNMPVALUE},FAN]'
               delay: '300'
-              request_method: POST
               trigger_prototypes:
                 -
                   uuid: d16b7a342c824cbab29e21da46cc2ca1
@@ -471,8 +450,6 @@ zabbix_export:
                 ENTITY-SENSOR-MIB::entPhySensorValue&#13;
                 &#13;
                 The most recent measurement obtained by the agent for this sensor.
-              request_method: POST
-          request_method: POST
         -
           uuid: b133aa1d7a854de38ad786767b5a4148
           name: '$1 Discovery'
@@ -496,7 +473,6 @@ zabbix_export:
               key: 'entPhySensorOperStatus[{#SNMPINDEX},TEMPERATURE]'
               delay: '300'
               description: 'Discovery of alarm status at temperature sensor'
-              request_method: POST
             -
               uuid: f3d1cc596b2d441496d501393eb358e9
               name: '{#SNMPVALUE}'
@@ -506,7 +482,6 @@ zabbix_export:
               delay: '60'
               units: °C
               description: 'Temperature item discovery'
-              request_method: POST
           trigger_prototypes:
             -
               uuid: 10fd5d3288684fb4a6b43bfc7a1b2094
@@ -523,7 +498,6 @@ zabbix_export:
                   item:
                     host: 'Template Palo Alto Firewall'
                     key: 'entPhySensorValue[{#SNMPINDEX},TEMPERATURE]'
-          request_method: POST
       valuemaps:
         -
           uuid: 671ec64bb00d4d38839b00dbe59db977


### PR DESCRIPTION
This removes the request_method = POST from all items according to [this](https://www.zabbix.com/forum/zabbix-troubleshooting-and-problems/461658-error-importing-template) forum post, and [this](https://support.zabbix.com/browse/ZBX-22669) support ticket.

The templates now import correctly into Zabbix 6.4.

You'll probably need to create a zabbix_v6.4 branch for this.